### PR TITLE
Fix pdf template settings page js error

### DIFF
--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -300,13 +300,20 @@ if ( class_exists( 'GFForms' ) ) {
 						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflowpdf&fid=0' ),
 					),
 					'strings' => array(
-						'feedId' => absint( rgget( 'fid' ) ),
-						'formId' => absint( rgget( 'id' ) ),
-						'mergeTagLabels' => gravity_flow()->get_form_settings_js_merge_tag_labels(),
+						'feedId'                    => absint( rgget( 'fid' ) ),
+						'formId'                    => absint( rgget( 'id' ) ),
+						'mergeTagLabels'            => gravity_flow()->get_form_settings_js_merge_tag_labels(),
+						'assigneeSearchPlaceholder' => esc_attr__( 'Type to search', 'gravityflowpdf' ),
 					),
 
 				),
-
+				array(
+					'handle'  => 'gravityflow_quicksearch',
+					'enqueue' => array(
+						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflowpdf&fid=_notempty_' ),
+						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflowpdf&fid=0' ),
+					),
+				),
 
 			);
 


### PR DESCRIPTION
re: [HS#6280](https://secure.helpscout.net/conversation/612970303/6280?folderId=1113492)

On the Form Settings > PDF > PDF Template Settings page a JavaScript error related to the Gravity Flow assignee search enhancements in present. 

> form-settings.js?ver=2.2.3-dev:23 Uncaught TypeError: $selectableSearch.quicksearch is not a function

This JS error is preventing the email settings from being hidden and the tinymce tabs and add media button from functioning.

Adding quicksearch.js and the search input placeholder string to the gravityflow_form_settings_js for the gravityflowpdf subview resolves the issue.

**Testing Instructions**

With master check the Form Settings > PDF > PDF Template Settings page and find the aforementioned issues.

With this branch find those issues are resolved. Check the workflow step settings page to ensure the assignee search feature functions correctly.