### PR TITLE
Change get_file_path to apply filter gravityflowpdf_file_name through use of get_file_name

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue where pdf filename did not pass through the gravityflowpdf_file_name filter before creation.

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -504,7 +504,7 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$folder = $this->get_destination_folder();
 
-			$path = $folder . $entry_id . '.pdf';
+			$path = $folder . $this->get_file_name( $entry_id, $form_id );
 			$path = apply_filters( 'gravityflowpdf_file_path', $path, $entry_id, $form_id );
 
 			return $path;

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -81,14 +81,14 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			$notification_type = $this->workflow_notification_type;
 
 			switch ( $notification_type ) {
-				case 'select' :
+				case 'select':
 					if ( is_array( $this->workflow_notification_users ) ) {
 						foreach ( $this->workflow_notification_users as $assignee_key ) {
 							$assignees[] = new Gravity_Flow_Assignee( $assignee_key, $this );
 						}
 					}
 					break;
-				case 'routing' :
+				case 'routing':
 					$routings = $this->workflow_notification_routing;
 					if ( is_array( $routings ) ) {
 						foreach ( $routings as $routing ) {


### PR DESCRIPTION
Refer to HS 7728 for additional details.

The generation of .pdf was not consistently applying the gravityflowpdf_file_name filter.

**Example filter hook for testing**
```
add_filter( 'gravityflowpdf_file_name', 'sh_gravityflowpdf_file_name', 10, 3 );
function sh_gravityflowpdf_file_name( $file_name, $entry_id, $form_id ) {
	return 'demo-' . $file_name;
}
```

**Testing Instructions**

* Activate GravityFlowPDF add-on with original master branch
* Include filter snippet above in functions.php or site plugin
* Create form with a PDF template (feed) and specify to attach pdf as file.
* Complete workflow and note that the attachment does not include demo- in filename of attachment
* Change pdf template to not attach file
* Repeat workflow and access PDF at yourserver.com/?gravityflow-pdf-entry-id=999
(replace 999 with the ID of the entry)
* Note that pdf does not have demo- in downloaded file
* Switch to branch of PR and repeat tests. File will have demo- in each case.
