### PR TITLE
Add $entry and $step params to gravityflowpdf_mpdf_config / gravityflowpdf_content

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,1 @@
-
+- Added parameters ($entry and $step) to filters gravityflowpdf_mpdf_config and gravityflowpdf_content to enable more granular customization options.

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -517,7 +517,7 @@ if ( class_exists( 'GFForms' ) ) {
 		 * @return string
 		 * @throws \Mpdf\MpdfException
 		 */
-		public function generate_pdf( $body, $file_path ) {
+		public function generate_pdf( $body, $file_path, $entry = false, $step = false ) {
 			if ( ! class_exists( '\Mpdf\Mpdf' ) ) {
 				require_once( 'vendor/autoload.php' );
 			}
@@ -533,10 +533,15 @@ if ( class_exists( 'GFForms' ) ) {
 			 * Allow the mPDF initialization properties to be overridden.
 			 *
 			 * @since 1.1.3
+			 * @since 1.3.2 Added the $entry and $step arguments
 			 *
-			 * @param array $mpdf_config The mPDF initialization properties. See https://mpdf.github.io/reference/mpdf-variables/overview.html
+			 * @param array                  $mpdf_config The mPDF initialization properties. See https://mpdf.github.io/reference/mpdf-variables/overview.html
+			 * @param bool|array             $entry The current entry.
+			 * @param bool|Gravity_Flow_Step $step The current step.
+			 *
+			 * @return array
 			 */
-			$mpdf_config = apply_filters( 'gravityflowpdf_mpdf_config', $mpdf_config );
+			$mpdf_config = apply_filters( 'gravityflowpdf_mpdf_config', $mpdf_config, $entry, $step );
 
 			$mpdf = new \Mpdf\Mpdf( $mpdf_config );
 
@@ -546,9 +551,36 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$mpdf->SetCreator( 'Gravity Flow v' . GRAVITY_FLOW_VERSION . '. https://gravityflow.io' );
 
-			$body = apply_filters( 'gravityflowpdf_content', $body, $file_path );
+			/**
+			 * Allow the content for PDF creation to be overridden.
+			 *
+			 * @since unknown
+			 * @since 1.3.2   Added the $entry and $step parameters
+			 *
+			 * @param string                 $body      The markup for PDF as defined through step settings.
+			 * @param string                 $file_path The path that PDF will be saved to.
+			 * @param bool|array             $entry     The current entry.
+			 * @param bool|Gravity_Flow_Step $step      The current step.
+			 *
+			 * @return string
+			 */
+			$body = apply_filters( 'gravityflowpdf_content', $body, $file_path, $entry, $step );
 
-			$mpdf = apply_filters( 'gravityflowpdf_mpdf', $mpdf, $body, $file_path );
+			/**
+			 * Allow the content for PDF creation to be overridden.
+			 *
+			 * @since unknown
+			 * @since 1.3.2   Added the $entry and $step parameters
+			 *
+			 * @param Mpdf\Mpdf              $mpdf      The mpdf instance - See https://mpdf.github.io/reference/mpdf-variables/overview.html
+			 * @param string                 $body      The markup for PDF as defined through step settings.
+			 * @param string                 $file_path The path that PDF will be saved to.
+			 * @param bool|array             $entry     The current entry.
+			 * @param bool|Gravity_Flow_Step $step      The current step.
+			 *
+			 * @return Mpdf\Mpdf
+			 */
+			$mpdf = apply_filters( 'gravityflowpdf_mpdf', $mpdf, $body, $file_path, $entry, $step );
 
 			$mpdf->WriteHTML( $body );
 

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -511,8 +511,10 @@ if ( class_exists( 'GFForms' ) ) {
 		}
 
 		/**
-		 * @param string $body The PDF content.
-		 * @param string $file_path The PDF path.
+		 * @param string                 $body      The PDF content.
+		 * @param string                 $file_path The PDF path.
+		 * @param bool|array             $entry     The current entry.
+		 * @param bool|Gravity_Flow_Step $step      The current step.
 		 *
 		 * @return string
 		 * @throws \Mpdf\MpdfException
@@ -536,8 +538,8 @@ if ( class_exists( 'GFForms' ) ) {
 			 * @since 1.3.2 Added the $entry and $step arguments
 			 *
 			 * @param array                  $mpdf_config The mPDF initialization properties. See https://mpdf.github.io/reference/mpdf-variables/overview.html
-			 * @param bool|array             $entry The current entry.
-			 * @param bool|Gravity_Flow_Step $step The current step.
+			 * @param bool|array             $entry       The current entry.
+			 * @param bool|Gravity_Flow_Step $step        The current step.
 			 *
 			 * @return array
 			 */

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -101,7 +101,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 
 			$file_path = gravity_flow_pdf()->get_file_path( $this->get_entry_id(), $form['id'] );
 
-			gravity_flow_pdf()->generate_pdf( $body, $file_path );
+			gravity_flow_pdf()->generate_pdf( $body, $file_path, $entry, $this );
 		}
 
 		public function send_email() {


### PR DESCRIPTION
See [HS#9958](https://secure.helpscout.net/conversation/898817504/9958?folderId=1776095)

Prior to this PR, the gravityflowpdf_mpdf instance could not be customized on a per entry or per step basis to, for example, add or adjust the watermark. It adds $entry and $step parameters to 2 filters - gravityflowpdf_mpdf_config and gravityflowpdf_content - to enable such customization. Defaults (of false) are set via their parent function generate_pdf to ensure backward compatibility.

**Test Instructions**
- Setup a workflow with 2 separate PDF steps
- Note that in master branch execution the watermark cannot be customized per step
- Switch to this PR branch
- Apply filter similar to the one included below to control watermark by Step ID

``` 
add_filter( 'gravityflowpdf_mpdf', 'sh_gravityflowpdf_mpdf', 10, 5 );
function sh_gravityflowpdf_mpdf( $mpdf, $body, $file_path, $entry, $step ) {
	if ( ! empty( $step ) && $step->get_id() == '75' ) {
		$mpdf->SetWatermarkText( 'DRAFT' );
		$mpdf->showWatermarkText = true;
	}
	return $mpdf;
}
```
