### PR TITLE
Extend settings + UI to always show CC field

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Added parameters ($entry and $step) to filters gravityflowpdf_mpdf_config and gravityflowpdf_content to enable more granular customization options.
+- Added step setting for notifications to identify CC: recipients

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -573,9 +573,6 @@ if ( class_exists( 'GFForms' ) ) {
 			 *
 			 * @return string
 			 */
-			//error_log( "START GENERATE ----------------------------------------------------------");
-			//error_log( $body );
-			//error_log( "END GENERATE ----------------------------------------------------------");
 			$body = apply_filters( 'gravityflowpdf_content', $body, $file_path, $entry, $step );
 
 			/**
@@ -596,7 +593,6 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$mpdf->WriteHTML( $body );
 
-			error_log('File Path: ' . $file_path );
 			$mpdf->Output( $file_path );
 
 			return $file_path;

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -242,6 +242,12 @@ if ( class_exists( 'GFForms' ) ) {
 						'type'  => 'text',
 					),
 					array(
+						'name'  => 'workflow_notification_cc',
+						'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
+						'label' => __( 'CC', 'gravityflowpdf' ),
+						'type'  => 'text',
+					),
+					array(
 						'name'  => 'workflow_notification_bcc',
 						'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
 						'label' => __( 'BCC', 'gravityflowpdf' ),

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -246,6 +246,7 @@ if ( class_exists( 'GFForms' ) ) {
 						'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
 						'label' => __( 'CC', 'gravityflowpdf' ),
 						'type'  => 'text',
+						'tooltip'  => '<h6>' . __( 'Name', 'gravityflow' ) . '</h6>' . __( 'Be aware of any privacy policies your website is subject to that would apply to using the CC field. For example, GDPR indicates names and emails are private that should not be exposed.', 'gravityflow' ),
 					),
 					array(
 						'name'  => 'workflow_notification_bcc',
@@ -572,6 +573,9 @@ if ( class_exists( 'GFForms' ) ) {
 			 *
 			 * @return string
 			 */
+			//error_log( "START GENERATE ----------------------------------------------------------");
+			//error_log( $body );
+			//error_log( "END GENERATE ----------------------------------------------------------");
 			$body = apply_filters( 'gravityflowpdf_content', $body, $file_path, $entry, $step );
 
 			/**
@@ -592,6 +596,7 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$mpdf->WriteHTML( $body );
 
+			error_log('File Path: ' . $file_path );
 			$mpdf->Output( $file_path );
 
 			return $file_path;

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -198,7 +198,9 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 
 			$this->log_debug( __METHOD__ . '() - sending notification: ' . print_r( $notification, true ) );
 
+			add_filter( 'gform_notification_enable_cc', '__return_true' );
 			GFCommon::send_notification( $notification, $form, $entry );
+			remove_filter( 'gform_notification_enable_cc', '__return_true' );
 
 		}
 

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -143,6 +143,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			$notification['fromName']                   = $this->workflow_notification_from_name;
 			$notification['from']                       = $this->workflow_notification_from_email;
 			$notification['replyTo']                    = $this->workflow_notification_reply_to;
+			$notification['cc']                         = $this->workflow_notification_cc;
 			$notification['bcc']                        = $this->workflow_notification_bcc;
 			$notification['subject']                    = $this->workflow_notification_subject;
 			$notification['message']                    = $this->workflow_notification_message;


### PR DESCRIPTION
Refer to [GFlow PR#278](https://github.com/gravityflow/gravityflow/pull/278)

This PR adds the option for CC: to be included for the PDF step notifications. 

**Testing Instructions**

- Enable the fix-10250-enable-cc branch
- Test that all pdf notification scenarios include an option for CC: distribution
- Confirm that notifications deliver with CC: users/emails specified

**Deployment Instructions**
Should have it's merge/version release timed with GFlow PR#278
