### PR TITLE
Update the form settings label to "Workflow PDF"

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Update the form settings label to "Workflow PDF".

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -100,6 +100,28 @@ if ( class_exists( 'GFForms' ) ) {
 			return $caps;
 		}
 
+		/**
+		 * Add the form settings tab.
+		 *
+		 * @since 1.3.4
+		 *
+		 * @param array $tabs    The form settings.
+		 * @param int   $form_id The form ID.
+		 *
+		 * @return array
+		 */
+		public function add_form_settings_menu( $tabs, $form_id ) {
+
+			$tabs[] = array(
+				'name'         => $this->_slug,
+				'label'        => gravity_flow()->translate_navigation_label( 'workflow' ) . ' PDF',
+				'query'        => array( 'fid' => null ),
+				'capabilities' => $this->_capabilities_form_settings,
+			);
+
+			return $tabs;
+		}
+
 		public function feed_settings_fields() {
 			$account_choices = gravity_flow()->get_users_as_choices();
 			$feed_settings   = array(


### PR DESCRIPTION
re:[HS#11298](https://secure.helpscout.net/conversation/990444802/11298/)

This PR updates the form settings label from "PDF" to "Workflow PDF", so it won't be duplicated with Gravity PDF. We use the translated label for "Workflow" so it would be changed depends on the language setting.

<img width="696" alt="Screenshot 2019-11-07 23 57 43" src="https://user-images.githubusercontent.com/12166/68405111-7f545700-01ba-11ea-864b-34a816cb154b.png">


