### PR TITLE
Added option to set PDF File Name on the Workflow Settings

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,5 @@
 - Update the form settings label to "Workflow PDF".
 - Updated mPDF to v8.0.4.
 - Fixed PHP notices thrown in PHP 7.4.
+- Added option to set PDF File Name on the Workflow. Empty field takes the current defined default value.
+- Added merge tag support for PDF File Name field.

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -184,6 +184,14 @@ if ( class_exists( 'GFForms' ) ) {
 				'title'  => 'PDF',
 				'fields' => array(
 					array(
+						'name'     => 'file_name',
+						'label'    => __( 'PDF Name', 'gravityflowpdf' ),
+						'type'     => 'text',
+						'class'    => 'medium merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
+						'required' => false,
+						'tooltip'  => '<h6>' . __( 'PDF Name', 'gravityflowpdf' ) . '</h6>' . __( 'Enter a name to uniquely identify this pdf. Leave empty for default file name.', 'gravityflowpdf' ),
+					),					
+					array(
 						'name'          => 'template',
 						'label'         => esc_html__( 'Template', 'gravityflowpdf' ),
 						'type'          => 'textarea',
@@ -637,7 +645,7 @@ if ( class_exists( 'GFForms' ) ) {
 			return $path;
 		}
 
-		function get_destination_folder() {
+		public function get_destination_folder() {
 			$upload_dir = wp_upload_dir();
 			$path       = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'gravityflowpdf' . DIRECTORY_SEPARATOR;
 			if ( ! is_dir( $path ) ) {

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -189,7 +189,7 @@ if ( class_exists( 'GFForms' ) ) {
 						'type'     => 'text',
 						'class'    => 'medium merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
 						'required' => false,
-						'tooltip'  => '<h6>' . __( 'PDF Name', 'gravityflowpdf' ) . '</h6>' . __( 'Enter a name to uniquely identify this pdf. Leave empty for default file name.', 'gravityflowpdf' ),
+						'tooltip'  => '<h6>' . __( 'PDF Name', 'gravityflowpdf' ) . '</h6>' . __( 'Enter a name to uniquely identify this pdf. Leave empty for default file name format (form-##-entry-##.pdf).', 'gravityflowpdf' ),
 					),					
 					array(
 						'name'          => 'template',

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -99,7 +99,13 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 				$body = do_shortcode( $body );
 			}
 
-			$file_path = gravity_flow_pdf()->get_file_path( $this->get_entry_id(), $form['id'] );
+			if ( empty( $this->file_name ) ) {
+				$file_path = gravity_flow_pdf()->get_file_path( $this->get_entry_id(), $form['id'] );
+			}
+			else {
+				$file_name = GFCommon::replace_variables( $this->file_name, $this->get_form(), $entry, true, false, false, 'text' );
+				$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name . ".pdf";
+			}
 
 			gravity_flow_pdf()->generate_pdf( $body, $file_path, $entry, $this );
 		}

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -105,10 +105,9 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			else {
 				$file_name = GFCommon::replace_variables( $this->file_name, $this->get_form(), $entry, true, false, false, 'text' );
 				$file_parts = pathinfo( strtolower( $file_name ) );
-				if( $file_parts['extension'] == 'pdf' ) {
+				if ( isset( $file_parts['extension'] ) && 'pdf' === $file_parts['extension'] ) {
 					$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name;
-				}
-				else {
+				} else {
 					$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name . '.pdf';
 				}
 			}

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -104,7 +104,13 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			}
 			else {
 				$file_name = GFCommon::replace_variables( $this->file_name, $this->get_form(), $entry, true, false, false, 'text' );
-				$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name . ".pdf";
+				$file_parts = pathinfo( strtolower( $file_name ) );
+				if( $file_parts['extension'] == 'pdf' ) {
+					$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name;
+				}
+				else {
+					$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name . '.pdf';
+				}
 			}
 
 			gravity_flow_pdf()->generate_pdf( $body, $file_path, $entry, $this );


### PR DESCRIPTION
### Description
Add a setting to the PDF step settings and PDF template settings to allow the file name to be set. The setting will support merge tags and default to the filename currently defined in the code.
Trello task link: https://trello.com/c/VNNerM3J/516-add-pdf-filename-setting-with-merge-tag-support

### Testing instructions

1. Add a PDF Step on the Workflow.
2. Enter a PDF name, e.g., `test.` The PDF file generated would be `test.pdf`
3. Next, leave the PDF name blank and generate an entry. The PDF file generated must follow the default nomenclature, like `form-147-entry-1178.pdf` (where 147 is the form ID, and 1178 is the entry ID).
4. Finally, use a merge tag on the PDF name, e.g.,`{entry_id}.` The PDF file generated would be `1179.pdf` (where 1179 is the entry ID).

### Screenshots
N/A

### Documentation Changes?
https://docs.gravityflow.io/article/77-pdf-generator-documentation
The documentation would need an update with new screenshots and information on how we can set the file name in this workflow step.

### Checklist:
- [x]  I've tested the code.
- [x]  My code follows the WordPress code style.
- [x]  My code follows the accessibility standards.
- [x]  My code follows the inline documentation standards.