### PR TITLE
Update Gravity Flow PDF Step to use 'Checkbox and Text' Setting

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,3 +3,5 @@
 - Fixed PHP notices thrown in PHP 7.4.
 - Added option to set PDF File Name on the Workflow. Empty field takes the current defined default value.
 - Added merge tag support for PDF File Name field.
+- Updated the Custom file name on the workflow step to work as 'Checkbox and text', to give user either the option of using the default file name or defining a custom one.
+- Updated filter 'gravityflowpdf_file_name' call to also work when a custom file name is defined on the workflow step.

--- a/change_log.txt
+++ b/change_log.txt
@@ -3,5 +3,5 @@
 - Fixed PHP notices thrown in PHP 7.4.
 - Added option to set PDF File Name on the Workflow. Empty field takes the current defined default value.
 - Added merge tag support for PDF File Name field.
-- Updated the Custom file name on the workflow step to work as 'Checkbox and text', to give user either the option of using the default file name or defining a custom one.
-- Updated filter 'gravityflowpdf_file_name' call to also work when a custom file name is defined on the workflow step.
+- Added custom file name setting (enable checkbox + text) to allow customization of PDF file name.
+- Added gravityflowpdf_file_name filter call to apply when a custom file name is defined on the workflow step.

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -697,11 +697,11 @@ if ( class_exists( 'GFForms' ) ) {
 			/**
 			 * Allows changing the default name of the PDF file generated.
 			 *
-			 * @since unknown
+			 * @since 1.1
 			 *
-			 * @param string                 $file_name The name of PDF as defined through step settings.
-			 * @param int		                 $entry_id	The entry id of the current entry.
-			 * @param int				             $form_id   The form id of the current form.
+			 * @param string    $file_name  The name of PDF as defined through step settings.
+			 * @param int       $entry_id   The entry id of the current entry.
+			 * @param int       $form_id    The form id of the current form.
 			 *
 			 * @return string
 			 */

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -694,6 +694,17 @@ if ( class_exists( 'GFForms' ) ) {
 		public function get_file_name( $entry_id, $form_id ) {
 			$file_name = 'form-' . $form_id . '-entry-' . $entry_id . '.pdf';
 
+			/**
+			 * Allows changing the default name of the PDF file generated.
+			 *
+			 * @since unknown
+			 *
+			 * @param string                 $file_name The name of PDF as defined through step settings.
+			 * @param int		                 $entry_id	The entry id of the current entry.
+			 * @param int				             $form_id   The form id of the current form.
+			 *
+			 * @return string
+			 */
 			return apply_filters( 'gravityflowpdf_file_name', $file_name, $entry_id, $form_id );
 		}
 

--- a/class-gravity-flow-pdf.php
+++ b/class-gravity-flow-pdf.php
@@ -184,12 +184,20 @@ if ( class_exists( 'GFForms' ) ) {
 				'title'  => 'PDF',
 				'fields' => array(
 					array(
-						'name'     => 'file_name',
-						'label'    => __( 'PDF Name', 'gravityflowpdf' ),
-						'type'     => 'text',
-						'class'    => 'medium merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
-						'required' => false,
-						'tooltip'  => '<h6>' . __( 'PDF Name', 'gravityflowpdf' ) . '</h6>' . __( 'Enter a name to uniquely identify this pdf. Leave empty for default file name format (form-##-entry-##.pdf).', 'gravityflowpdf' ),
+						'name'     => 'custom_file_name',
+						'label'    => __( 'Custom File Name', 'gravityflowpdf' ),
+						'type'     => 'checkbox_and_text',
+						'tooltip'  => '<h6>' . __( 'Custom File Name', 'gravityflowpdf' ) . '</h6>' . __( 'Enter a name to uniquely identify this PDF. Default file name format is "form-##-entry-##.pdf".', 'gravityflowpdf' ),
+						'checkbox' => array(
+							'name'          => 'enable_file_name',
+							'label'         => __( 'Enabled', 'gravityflowpdf' ),
+						),
+						'text'     => array(
+							'name'          => 'file_name',
+							'class'         => 'medium merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
+							'placeholder'   => 'form-{form_id}-entry-{entry_id}.pdf',
+							'before'        => '<br />',
+						),						
 					),					
 					array(
 						'name'          => 'template',

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -99,7 +99,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 				$body = do_shortcode( $body );
 			}
 
-			if ( empty( $this->file_name ) ) {
+			if ( ! $this->enable_file_name || empty( $this->file_name ) ) {
 				$file_path = gravity_flow_pdf()->get_file_path( $this->get_entry_id(), $form['id'] );
 			}
 			else {

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -106,16 +106,16 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 				$file_name = GFCommon::replace_variables( $this->file_name, $this->get_form(), $entry, true, false, false, 'text' );
 
 				/**
-				 * Allows changing the custom name of the PDF file generated.
-				 *
-				 * @since unknown
-				 *
-				 * @param string                 $file_name name of PDF as defined through step settings.
-				 * @param int		                 $entry_id	The entry id of the current entry.
-				 * @param int				             $form_id   The form id of the current form.
-				 *
-				 * @return string
-				 */				
+				* Allows changing the default name of the PDF file generated.
+				*
+				* @since 1.1
+				*
+				* @param string    $file_name  The name of PDF as defined through step settings.
+				* @param int       $entry_id   The entry id of the current entry.
+				* @param int       $form_id    The form id of the current form.
+				*
+				* @return string
+				*/
 				$file_name = apply_filters( 'gravityflowpdf_file_name', $file_name, $entry_id, $form_id );
 
 				$file_parts = pathinfo( strtolower( $file_name ) );

--- a/includes/class-gravity-flow-step-pdf.php
+++ b/includes/class-gravity-flow-step-pdf.php
@@ -104,6 +104,20 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			}
 			else {
 				$file_name = GFCommon::replace_variables( $this->file_name, $this->get_form(), $entry, true, false, false, 'text' );
+
+				/**
+				 * Allows changing the custom name of the PDF file generated.
+				 *
+				 * @since unknown
+				 *
+				 * @param string                 $file_name name of PDF as defined through step settings.
+				 * @param int		                 $entry_id	The entry id of the current entry.
+				 * @param int				             $form_id   The form id of the current form.
+				 *
+				 * @return string
+				 */				
+				$file_name = apply_filters( 'gravityflowpdf_file_name', $file_name, $entry_id, $form_id );
+
 				$file_parts = pathinfo( strtolower( $file_name ) );
 				if ( isset( $file_parts['extension'] ) && 'pdf' === $file_parts['extension'] ) {
 					$file_path = gravity_flow_pdf()->get_destination_folder() . $file_name;


### PR DESCRIPTION
## Description

1. Changed the field label to 'Custom File Name' (from PDF Name)
2. Changed the setting type from text to `checkbox_and_text`.
3. Added input field placeholder - **form-{form_id}-entry-{entry_id}.pdf** - that helps users see the default before the click into the field to customize.

## Testing instructions
1. Test with checkbox disabled.
> Default file name will be used (form-{form_id}-entry-{entry_id}.pdf)
2. Test with checkbox enabled and a custom file name entered.
> User entered file name will be used.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
A note and screenshots should be updated here: https://docs.gravityflow.io/article/77-pdf-generator-documentation

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->